### PR TITLE
Implement MCP23017 input-driven LED toggling with debounce

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,4 @@
 platform = espressif8266
 board = d1_mini
 framework = arduino
+lib_deps = adafruit/Adafruit MCP23X17

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,18 +1,66 @@
 #include <Arduino.h>
+#include <Wire.h>
+#include <Adafruit_MCP23X17.h>
 
-// put function declarations here:
-int myFunction(int, int);
+constexpr uint8_t NUM_CHIPS = 3;
+constexpr uint8_t NUM_PINS = 6;
+const uint8_t ADDRESSES[NUM_CHIPS] = {0x20, 0x21, 0x22};
+Adafruit_MCP23X17 mcp[NUM_CHIPS];
+
+struct ButtonData {
+  uint8_t ledPin;
+  uint8_t btnPin;
+  bool ledState;
+  bool buttonState;
+  bool lastReading;
+  unsigned long lastDebounceTime;
+};
+
+ButtonData buttons[NUM_CHIPS][NUM_PINS];
+const unsigned long DEBOUNCE_DELAY = 50; // milliseconds
 
 void setup() {
-  // put your setup code here, to run once:
-  int result = myFunction(2, 3);
+  Wire.begin(D2, D1); // SDA, SCL
+
+  for (uint8_t chip = 0; chip < NUM_CHIPS; ++chip) {
+    mcp[chip].begin_I2C(ADDRESSES[chip]);
+    for (uint8_t pin = 0; pin < NUM_PINS; ++pin) {
+      ButtonData &b = buttons[chip][pin];
+      b.ledPin = pin;           // GPA0-GPA5
+      b.btnPin = 8 + pin;       // GPB0-GPB5
+      b.ledState = false;
+      b.buttonState = HIGH;     // pull-up -> unpressed
+      b.lastReading = HIGH;
+      b.lastDebounceTime = 0;
+
+      mcp[chip].pinMode(b.ledPin, OUTPUT);
+      mcp[chip].digitalWrite(b.ledPin, LOW);
+      mcp[chip].pinMode(b.btnPin, INPUT_PULLUP);
+    }
+  }
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-}
+  for (uint8_t chip = 0; chip < NUM_CHIPS; ++chip) {
+    for (uint8_t pin = 0; pin < NUM_PINS; ++pin) {
+      ButtonData &b = buttons[chip][pin];
+      bool reading = mcp[chip].digitalRead(b.btnPin);
 
-// put function definitions here:
-int myFunction(int x, int y) {
-  return x + y;
+      if (reading != b.lastReading) {
+        b.lastDebounceTime = millis();
+      }
+
+      if ((millis() - b.lastDebounceTime) > DEBOUNCE_DELAY) {
+        if (reading != b.buttonState) {
+          b.buttonState = reading;
+          if (b.buttonState == LOW) {
+            b.ledState = !b.ledState;
+            mcp[chip].digitalWrite(b.ledPin, b.ledState ? HIGH : LOW);
+          }
+        }
+      }
+
+      b.lastReading = reading;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Configure PlatformIO environment to include the Adafruit MCP23X17 library
- Implement LED toggling on three chained MCP23017 expanders with input debouncing

## Testing
- ⚠️ `pip install -U platformio` (ProxyError: Tunnel connection failed)
- ⚠️ `pio run` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c751f3886883219f30de7c0a9a60d7