### PR TITLE
feat: improve mobile scheduler UX

### DIFF
--- a/server/state_server.py
+++ b/server/state_server.py
@@ -216,6 +216,20 @@ class Handler(BaseHTTPRequestHandler):
             except (KeyError, ValueError, TypeError):
                 pass
             self.send_error(400, "Bad Request")
+        elif self.path == "/schedule/delete":
+            try:
+                chip = int(data["chip"])
+                pin = int(data["pin"])
+                for s in list(SCHEDULES):
+                    if s["chip"] == chip and s["pin"] == pin:
+                        SCHEDULES.remove(s)
+                save_schedules()
+                self._set_json_headers()
+                self.wfile.write(b"{}")
+                return
+            except (KeyError, ValueError, TypeError):
+                pass
+            self.send_error(400, "Bad Request")
         else:
             self.send_error(404, "Not Found")
 

--- a/server/web/app.js
+++ b/server/web/app.js
@@ -1,11 +1,49 @@
 const API_BASE = `${window.location.protocol}//${window.location.hostname}:5000`;
 
-function fillSelect(select, max) {
-  for (let i = 0; i < max; i++) {
-    const opt = document.createElement('option');
-    opt.value = i;
-    opt.textContent = i;
-    select.appendChild(opt);
+const PIN_LAYOUT = [
+  [ [0,1], [0,0], [1,1], [1,0], [2,1], [2,0] ],
+  [ [0,3], [0,2], [1,3], [1,2], [2,3], [2,2] ],
+  [ [0,5], [0,4], [1,5], [1,4], [2,5], [2,4] ],
+];
+
+const PIN_LABELS = [
+  '1','2','3','4','5','6',
+  '7','8','9','10','11','12',
+  '13','14','15','16','17','18'
+];
+
+const scheduleMap = {};
+
+function buildGrid() {
+  const grid = document.getElementById('pin-grid');
+  PIN_LAYOUT.flat().forEach(([chip, pin], idx) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = PIN_LABELS[idx];
+    btn.dataset.chip = chip;
+    btn.dataset.pin = pin;
+    btn.addEventListener('click', () => handlePinClick(chip, pin));
+    grid.appendChild(btn);
+  });
+}
+
+function selectPin(chip, pin) {
+  document.getElementById('chip').value = chip;
+  document.getElementById('pin').value = pin;
+  document.querySelectorAll('#pin-grid button').forEach(b => b.classList.remove('selected'));
+  const btn = document.querySelector(`#pin-grid button[data-chip="${chip}"][data-pin="${pin}"]`);
+  if (btn) btn.classList.add('selected');
+}
+
+function handlePinClick(chip, pin) {
+  selectPin(chip, pin);
+  const sched = scheduleMap[`${chip}-${pin}`];
+  if (sched) {
+    populateForm(sched);
+  } else {
+    document.getElementById('form').reset();
+    selectPin(chip, pin);
+    document.getElementById('delete').classList.add('hidden');
   }
 }
 
@@ -14,16 +52,26 @@ async function fetchSchedules() {
   const data = await res.json();
   const tbody = document.querySelector('#schedule-list tbody');
   tbody.innerHTML = '';
+  Object.keys(scheduleMap).forEach(k => delete scheduleMap[k]);
+  document.querySelectorAll('#pin-grid button').forEach(b => b.classList.remove('scheduled'));
   const schedules = data.schedules.slice().reverse();
   schedules.forEach(s => {
+    scheduleMap[`${s.chip}-${s.pin}`] = s;
     const tr = document.createElement('tr');
     const due = new Date(s.due).toLocaleString();
-    tr.innerHTML = `<td>${s.name}</td><td>${s.chip}</td><td>${s.pin}</td>` +
+    tr.innerHTML = `<td>${s.name}</td><td>${labelFor(s.chip, s.pin)}</td>` +
                    `<td>${due}</td>` +
                    `<td>${formatInterval(s.repeat)}</td><td>${formatInterval(s.overdue)}</td>`;
     tr.addEventListener('click', () => populateForm(s));
     tbody.appendChild(tr);
+    const btn = document.querySelector(`#pin-grid button[data-chip="${s.chip}"][data-pin="${s.pin}"]`);
+    if (btn) btn.classList.add('scheduled');
   });
+}
+
+function labelFor(chip, pin) {
+  const idx = PIN_LAYOUT.flat().findIndex(([c,p]) => c === chip && p === pin);
+  return PIN_LABELS[idx] || `${chip}/${pin}`;
 }
 
 function formatInterval(obj) {
@@ -31,16 +79,59 @@ function formatInterval(obj) {
 }
 
 function populateForm(s) {
-  document.getElementById('chip').value = s.chip;
-  document.getElementById('pin').value = s.pin;
+  selectPin(s.chip, s.pin);
   document.getElementById('name').value = s.name || '';
   const dueDate = new Date(s.due);
   dueDate.setMinutes(dueDate.getMinutes() - dueDate.getTimezoneOffset());
   document.getElementById('due').value = dueDate.toISOString().slice(0,16);
+  const adv = document.getElementById('repeat-advanced');
+  adv.classList.add('hidden');
   document.getElementById('repeat-days').value = s.repeat?.days || '';
   document.getElementById('repeat-hours').value = s.repeat?.hours || '';
+  if (s.repeat && !((s.repeat.days === 1 || s.repeat.days === 7) && !s.repeat.hours)) {
+    adv.classList.remove('hidden');
+  }
   document.getElementById('overdue-days').value = s.overdue?.days || '';
   document.getElementById('overdue-hours').value = s.overdue?.hours || '';
+  document.getElementById('delete').classList.remove('hidden');
+}
+
+function applyDuePreset(type) {
+  const input = document.getElementById('due');
+  const now = new Date();
+  let target = new Date(now);
+  switch(type) {
+    case 'morning':
+      target.setHours(8,0,0,0);
+      if (target <= now) target.setDate(target.getDate()+1);
+      break;
+    case 'evening':
+      target.setHours(18,0,0,0);
+      if (target <= now) target.setDate(target.getDate()+1);
+      break;
+    case 'plus1d':
+      target = new Date(now.getTime() + 24*60*60*1000);
+      break;
+    case 'plus3d':
+      target = new Date(now.getTime() + 3*24*60*60*1000);
+      break;
+    case 'nextweek':
+      target = new Date(now.getTime() + 7*24*60*60*1000);
+      break;
+    default:
+      return;
+  }
+  target.setMinutes(target.getMinutes() - target.getTimezoneOffset());
+  input.value = target.toISOString().slice(0,16);
+}
+
+function setRepeatPreset(type) {
+  const adv = document.getElementById('repeat-advanced');
+  adv.classList.add('hidden');
+  document.getElementById('repeat-days').value = '';
+  document.getElementById('repeat-hours').value = '';
+  if (type === 'daily') document.getElementById('repeat-days').value = 1;
+  if (type === 'weekly') document.getElementById('repeat-days').value = 7;
 }
 
 async function submitForm(e) {
@@ -63,6 +154,8 @@ async function submitForm(e) {
   if (overdueDays) overdue.days = parseInt(overdueDays, 10);
   if (overdueHours) overdue.hours = parseInt(overdueHours, 10);
   if (Object.keys(overdue).length) payload.overdue = overdue;
+  const summary = `Save schedule for slot ${labelFor(payload.chip, payload.pin)}?`;
+  if (!confirm(summary)) return;
   await fetch(`${API_BASE}/schedule`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -72,7 +165,29 @@ async function submitForm(e) {
   fetchSchedules();
 }
 
-fillSelect(document.getElementById('chip'), 3);
-fillSelect(document.getElementById('pin'), 6);
+async function deleteSchedule() {
+  const chip = parseInt(document.getElementById('chip').value, 10);
+  const pin = parseInt(document.getElementById('pin').value, 10);
+  if (!confirm(`Delete schedule for slot ${labelFor(chip, pin)}?`)) return;
+  await fetch(`${API_BASE}/schedule/delete`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chip, pin })
+  });
+  document.getElementById('form').reset();
+  fetchSchedules();
+}
+
+buildGrid();
 fetchSchedules();
 document.getElementById('form').addEventListener('submit', submitForm);
+document.getElementById('delete').addEventListener('click', deleteSchedule);
+document.getElementById('show-advanced').addEventListener('click', () => {
+  document.getElementById('repeat-advanced').classList.remove('hidden');
+});
+document.querySelectorAll('.quick-due button').forEach(btn => {
+  btn.addEventListener('click', () => applyDuePreset(btn.dataset.due));
+});
+document.querySelectorAll('.repeat-presets button[data-repeat]').forEach(btn => {
+  btn.addEventListener('click', () => setRepeatPreset(btn.dataset.repeat));
+});

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Chore Schedules</title>
   <link rel="stylesheet" href="style.css" />
 </head>
@@ -11,7 +12,7 @@
     <section id="schedule-list">
       <table>
         <thead>
-          <tr><th>Name</th><th>Chip</th><th>Pin</th><th>Due</th><th>Repeat</th><th>Overdue</th></tr>
+          <tr><th>Name</th><th>Slot</th><th>Due</th><th>Repeat</th><th>Overdue</th></tr>
         </thead>
         <tbody></tbody>
       </table>
@@ -22,23 +23,34 @@
         <label>Name
           <input type="text" id="name" />
         </label>
-        <label>Chip
-          <select id="chip"></select>
-        </label>
-        <label>Pin
-          <select id="pin"></select>
-        </label>
+        <div id="pin-grid" class="pin-grid"></div>
+        <input type="hidden" id="chip" />
+        <input type="hidden" id="pin" />
         <label>Due
           <input type="datetime-local" id="due" required />
         </label>
+        <div class="quick-due">
+          <button type="button" data-due="morning">Morning</button>
+          <button type="button" data-due="evening">Evening</button>
+          <button type="button" data-due="plus1d">+1 day</button>
+          <button type="button" data-due="plus3d">+3 days</button>
+          <button type="button" data-due="nextweek">Next week</button>
+        </div>
         <fieldset>
           <legend>Repeat (optional)</legend>
+          <div class="repeat-presets">
+            <button type="button" data-repeat="daily">Every day</button>
+            <button type="button" data-repeat="weekly">Every week</button>
+            <button type="button" id="show-advanced">Advanced</button>
+          </div>
+          <div id="repeat-advanced" class="hidden">
           <label>Days
             <input type="number" id="repeat-days" min="0" />
           </label>
           <label>Hours
             <input type="number" id="repeat-hours" min="0" />
           </label>
+          </div>
         </fieldset>
         <fieldset>
           <legend>Overdue after (optional)</legend>
@@ -50,6 +62,7 @@
           </label>
         </fieldset>
         <button type="submit">Save</button>
+        <button type="button" id="delete" class="danger hidden">Delete</button>
       </form>
     </section>
   </div>

--- a/server/web/style.css
+++ b/server/web/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: system-ui, sans-serif;
-  margin: 2rem;
+  margin: 0;
   background: #f5f5f5;
   color: #333;
 }
@@ -9,7 +9,7 @@ body {
   max-width: 800px;
   margin: auto;
   background: #fff;
-  padding: 2rem;
+  padding: 1rem 2rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
@@ -39,6 +39,46 @@ fieldset {
   margin-bottom: 1rem;
 }
 
+.pin-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  margin-bottom: 1rem;
+}
+
+.pin-grid button {
+  padding: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.pin-grid button.scheduled {
+  background: #28a745;
+  color: #fff;
+}
+
+.pin-grid button.selected {
+  outline: 3px solid #0056b3;
+}
+
+.quick-due, .repeat-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 1rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.danger {
+  background: #dc3545;
+}
+
+.danger:hover {
+  background: #a71d2a;
+}
+
 button {
   padding: 0.5rem 1rem;
   border: none;
@@ -50,4 +90,27 @@ button {
 
 button:hover {
   background: #0056b3;
+}
+
+@media (max-width: 600px) {
+  .container {
+    max-width: 100%;
+    margin: 0;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 1rem;
+  }
+
+  .pin-grid {
+    gap: 2px;
+  }
+
+  .pin-grid button {
+    font-size: 0.9rem;
+  }
+
+  .quick-due button,
+  .repeat-presets button {
+    flex: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- Replace chip/pin numbers with human-friendly slot labels and prevent grid clicks from submitting the form
- Highlight scheduled slots in green and display slot labels in schedule list
- Revise quick due presets and add responsive mobile styling with viewport meta

## Testing
- `python -m py_compile server/state_server.py`
- `node --check server/web/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7a1d3d8108321b8cf5e534de2cafb